### PR TITLE
Update mqtt-protocol-core sso supported version (0.5.0).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-# 0.3.0 undetermined
+# 0.3.0
 
 ## Breaking changes
+
+* update mqtt-protocol-core to 0.5.0. The following feature flags are re-exported. #6
+  * `sso-min-32bit = ["mqtt-protocol-core/sso-min-32bit"]`
+  * `sso-min-64bit = ["mqtt-protocol-core/sso-min-64bit"]`
+  * `sso-lv10 = ["mqtt-protocol-core/sso-lv10"]`
+  * `sso-lv20 = ["mqtt-protocol-core/sso-lv20"]`
 
 * mqtt_ep::common::HashSet::default() should be called instead of mqtt::common::HashSet::new(). #5
 * connection_option recv_buffer_size is now Option. If omitted, internal value 4096 is used. #4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -530,7 +530,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "mqtt-protocol-core"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6645b95dcd8fd8bb199a903b62d4d5978f40605f495031208fe1e9bdeada082"
+checksum = "209826746f3459930193271ee6e68c696a5027cfb39d54ba6472be17929b43e8"
 dependencies = [
  "arrayvec",
  "delegate",
@@ -968,9 +968,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -1716,11 +1716,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1975,13 +1975,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["network-programming", "asynchronous", "api-bindings"]
 derive_builder = "0.20"
 getset = "0.1.5"
 tokio = { version = "1.0", features = ["net", "time", "rt", "rt-multi-thread", "macros", "sync"] }
-mqtt-protocol-core = "0.4"
+mqtt-protocol-core = "0.5"
 
 serde = { version = "1.0", features = ["derive"] }
 prefix_tree_map = "0.2"
@@ -36,8 +36,6 @@ futures = "0.3"
 
 # Logging (optional)
 tracing = { version = "0.1", optional = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"], optional = true }
-tracing-appender = { version = "0.2", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -45,10 +43,18 @@ num_cpus = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 rustls-pemfile = "1.0"
 url = "2.4"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"] }
+tracing-appender = { version = "0.2" }
 
 [features]
-default = ["logging"]
-logging = ["tracing", "tracing-subscriber", "tracing-appender"]
+default = []
+tracing = ["dep:tracing"]
+
+# Small String Optimization (SSO) features from mqtt-protocol-core
+sso-min-32bit = ["mqtt-protocol-core/sso-min-32bit"]
+sso-min-64bit = ["mqtt-protocol-core/sso-min-64bit"]
+sso-lv10 = ["mqtt-protocol-core/sso-lv10"]
+sso-lv20 = ["mqtt-protocol-core/sso-lv20"]
 
 # Release optimization settings
 [profile.release]

--- a/src/mqtt_ep/request_response.rs
+++ b/src/mqtt_ep/request_response.rs
@@ -33,6 +33,7 @@ use crate::mqtt_ep::packet_filter::PacketFilter;
 
 use tokio::sync::oneshot;
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum RequestResponse<PacketIdType>
 where
     PacketIdType: IsPacketId + Send + Sync,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,58 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Takatoshi Kondo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+use std::sync::Once;
+
+static INIT: Once = Once::new();
+
+/// Automatic tracing initialization for ALL tests
+///
+/// Environment variables:
+/// - `RUST_LOG`: Standard Rust logging (takes precedence if set)
+/// - `MQTT_LOG_LEVEL`: Set log level (trace, debug, info, warn, error). Default: warn
+///
+/// Usage examples:
+/// - `cargo test --features tracing` (default warn level)
+/// - `MQTT_LOG_LEVEL=trace cargo test --features tracing`
+/// - `RUST_LOG=debug cargo test --features tracing`
+fn auto_init_tracing() {
+    INIT.call_once(|| {
+        // Try RUST_LOG first, then MQTT_LOG_LEVEL, then default to warn
+        let filter = if let Ok(rust_log) = std::env::var("RUST_LOG") {
+            tracing_subscriber::EnvFilter::new(rust_log)
+        } else {
+            let level = std::env::var("MQTT_LOG_LEVEL").unwrap_or_else(|_| "warn".to_string());
+            tracing_subscriber::EnvFilter::new(format!("mqtt_endpoint_tokio={level}"))
+        };
+
+        tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .with_target(true)
+            .with_test_writer()
+            .init();
+    });
+}
+
+pub fn init_tracing() {
+    auto_init_tracing();
+}

--- a/tests/endpoint-close.rs
+++ b/tests/endpoint-close.rs
@@ -22,10 +22,13 @@
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 type ClientEndpoint = mqtt_ep::GenericEndpoint<mqtt_ep::role::Client, u16>;
 
 #[tokio::test]
 async fn test_close_api_compilation() {
+    common::init_tracing();
     // Test that the close API compiles correctly
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
     // Test that the close method exists and compiles
@@ -44,6 +47,7 @@ async fn test_close_api_compilation() {
 
 #[tokio::test]
 async fn test_close_with_different_roles() {
+    common::init_tracing();
     // Test close method with different roles
 
     // Test with Server role
@@ -70,6 +74,7 @@ async fn test_close_with_different_roles() {
 
 #[tokio::test]
 async fn test_operations_after_close() {
+    common::init_tracing();
     // Test that operations after close return appropriate errors
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
 

--- a/tests/endpoint-get-stored-packets.rs
+++ b/tests/endpoint-get-stored-packets.rs
@@ -22,12 +22,14 @@
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
 mod stub_transport;
 
 type ClientEndpoint = mqtt_ep::GenericEndpoint<mqtt_ep::role::Client, u16>;
 
 #[tokio::test]
 async fn test_get_stored_packets_api_compilation() {
+    common::init_tracing();
     // Test that the get_stored_packets API compiles correctly
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
 
@@ -52,6 +54,7 @@ async fn test_get_stored_packets_api_compilation() {
 
 #[tokio::test]
 async fn test_get_stored_packets_with_different_roles() {
+    common::init_tracing();
     // Test get_stored_packets method with different roles
 
     // Test with Server role
@@ -81,6 +84,7 @@ async fn test_get_stored_packets_with_different_roles() {
 
 #[tokio::test]
 async fn test_get_stored_packets_after_close() {
+    common::init_tracing();
     // Test that get_stored_packets after close returns appropriate errors
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
 
@@ -105,6 +109,7 @@ async fn test_get_stored_packets_after_close() {
 
 #[tokio::test]
 async fn test_restore_and_get_stored_packets_roundtrip() {
+    common::init_tracing();
     // Test the roundtrip: restore packets via connection options -> get stored packets
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
 

--- a/tests/endpoint-packet-id-wait.rs
+++ b/tests/endpoint-packet-id-wait.rs
@@ -25,10 +25,13 @@ use tokio::time::timeout;
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 type ClientEndpoint = mqtt_ep::GenericEndpoint<mqtt_ep::role::Client, u16>;
 
 #[tokio::test]
 async fn test_packet_id_when_available_api_compilation() {
+    common::init_tracing();
     // Test that the acquire_packet_id_when_available API compiles correctly
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
 
@@ -56,6 +59,7 @@ async fn test_packet_id_when_available_api_compilation() {
 
 #[tokio::test]
 async fn test_acquire_unique_vs_when_available_api() {
+    common::init_tracing();
     // Test that both packet ID acquisition methods compile
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V3_1_1);
 

--- a/tests/endpoint-recv-filter.rs
+++ b/tests/endpoint-recv-filter.rs
@@ -25,10 +25,13 @@ use tokio::time::timeout;
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 type ClientEndpoint = mqtt_ep::GenericEndpoint<mqtt_ep::role::Client, u16>;
 
 #[tokio::test]
 async fn test_packet_filter_matching() {
+    common::init_tracing();
     // Test Include filter
     let include_filter = mqtt_ep::PacketFilter::include(vec![
         mqtt_ep::packet::PacketType::Publish,

--- a/tests/endpoint-regulate-for-store.rs
+++ b/tests/endpoint-regulate-for-store.rs
@@ -22,10 +22,13 @@
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 type ClientEndpoint = mqtt_ep::GenericEndpoint<mqtt_ep::role::Client, u16>;
 
 #[tokio::test]
 async fn test_regulate_for_store_api_compilation() {
+    common::init_tracing();
     // Test that the regulate_for_store API compiles correctly
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V5_0);
 
@@ -57,6 +60,7 @@ async fn test_regulate_for_store_api_compilation() {
 
 #[tokio::test]
 async fn test_regulate_for_store_with_different_roles() {
+    common::init_tracing();
     // Test regulate_for_store method with different roles
 
     // Test with Server role
@@ -114,6 +118,7 @@ async fn test_regulate_for_store_with_different_roles() {
 
 #[tokio::test]
 async fn test_regulate_for_store_after_close() {
+    common::init_tracing();
     // Test that regulate_for_store after close returns appropriate errors
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V5_0);
 
@@ -147,6 +152,7 @@ async fn test_regulate_for_store_after_close() {
 
 #[tokio::test]
 async fn test_regulate_for_store_with_topic() {
+    common::init_tracing();
     // Test regulate_for_store with various packet configurations
     let endpoint: ClientEndpoint = mqtt_ep::GenericEndpoint::new(mqtt_ep::Version::V5_0);
 

--- a/tests/endpoint-send.rs
+++ b/tests/endpoint-send.rs
@@ -22,8 +22,11 @@
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 #[tokio::test]
 async fn test_send_concrete_packet() {
+    common::init_tracing();
     // Create a mock stream using duplex
 
     // Create mqtt_ep::GenericEndpoint for Client role with u16 packet ID
@@ -42,6 +45,7 @@ async fn test_send_concrete_packet() {
 
 #[tokio::test]
 async fn test_send_generic_packet() {
+    common::init_tracing();
     // Create a mock stream using duplex
 
     // Create mqtt_ep::GenericEndpoint for Client role with u16 packet ID
@@ -61,6 +65,7 @@ async fn test_send_generic_packet() {
 
 #[tokio::test]
 async fn test_send_with_different_roles() {
+    common::init_tracing();
     // Test with Server role
     {
         let endpoint: mqtt_ep::GenericEndpoint<mqtt_ep::role::Server, u16> =
@@ -83,6 +88,7 @@ async fn test_send_with_different_roles() {
 
 #[tokio::test]
 async fn test_packet_id_management() {
+    common::init_tracing();
     // Create a mock stream using duplex
 
     // Create mqtt_ep::GenericEndpoint for Client role with u16 packet ID
@@ -99,6 +105,7 @@ async fn test_packet_id_management() {
 
 #[tokio::test]
 async fn test_send_with_u32_packet_id() {
+    common::init_tracing();
     // Test with u32 packet ID type (for broker clustering)
 
     // Create mqtt_ep::GenericEndpoint for Client role with u32 packet ID

--- a/tests/endpoint-transport-calls.rs
+++ b/tests/endpoint-transport-calls.rs
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+mod common;
 mod stub_transport;
 
 use std::time::Duration;
@@ -33,6 +34,7 @@ type ClientEndpoint = mqtt_ep::GenericEndpoint<mqtt_ep::role::Client, u16>;
 
 #[tokio::test]
 async fn test_attach_accepts_connected_transport() {
+    common::init_tracing();
     let stub = StubTransport::new();
     // No connect response needed - transport is already "connected"
 
@@ -56,6 +58,7 @@ async fn test_attach_accepts_connected_transport() {
 
 #[tokio::test]
 async fn test_recv_calls_transport_recv() {
+    common::init_tracing();
     let mut stub = StubTransport::new();
 
     // Setup responses
@@ -89,6 +92,7 @@ async fn test_recv_calls_transport_recv() {
 
 #[tokio::test]
 async fn test_close_calls_shutdown() {
+    common::init_tracing();
     let mut stub = StubTransport::new();
     stub.add_response(TransportResponse::Shutdown);
 
@@ -117,6 +121,7 @@ async fn test_close_calls_shutdown() {
 
 #[tokio::test]
 async fn test_multiple_recv_attempts_for_unmatched_packets() {
+    common::init_tracing();
     let mut stub = StubTransport::new();
 
     // Setup responses

--- a/tests/mqtt-error-propagation.rs
+++ b/tests/mqtt-error-propagation.rs
@@ -25,8 +25,11 @@
 /// and returned as API responses instead of just being logged.
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 #[tokio::test]
 async fn test_mqtt_error_propagation_in_api_responses() {
+    common::init_tracing();
     println!("Testing MQTT error propagation in API responses");
 
     // Create a mock stream using duplex
@@ -64,6 +67,7 @@ async fn test_mqtt_error_propagation_in_api_responses() {
 
 #[tokio::test]
 async fn test_first_error_wins_policy() {
+    common::init_tracing();
     println!("Testing that first MQTT error wins when multiple errors occur");
 
     // This test demonstrates that when multiple NotifyError events occur

--- a/tests/transport-connect-helper.rs
+++ b/tests/transport-connect-helper.rs
@@ -22,6 +22,8 @@
 
 use mqtt_endpoint_tokio::mqtt_ep;
 
+mod common;
+
 use futures_util::SinkExt;
 use std::collections::HashMap;
 use std::fs::File;
@@ -333,6 +335,7 @@ async fn connect_tcp_tls_ws_for_test(
 
 #[tokio::test]
 async fn test_connect_tcp() {
+    common::init_tracing();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let addr = run_tcp_test_server("127.0.0.1:0", shutdown_rx).await;
 
@@ -365,6 +368,7 @@ async fn test_connect_tcp() {
 
 #[tokio::test]
 async fn test_connect_tcp_tls() {
+    common::init_tracing();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let addr = run_tls_test_server("127.0.0.1:0", shutdown_rx).await;
     let tls_config = load_client_tls_config();
@@ -414,6 +418,7 @@ async fn test_connect_tcp_tls() {
 
 #[tokio::test]
 async fn test_connect_tcp_ws() {
+    common::init_tracing();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let addr = run_ws_test_server("127.0.0.1:0", shutdown_rx).await;
 
@@ -467,6 +472,7 @@ async fn test_connect_tcp_ws() {
 
 #[tokio::test]
 async fn test_connect_tcp_tls_ws() {
+    common::init_tracing();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let addr = run_tls_ws_test_server("127.0.0.1:0", shutdown_rx).await;
     let tls_config = load_client_tls_config();


### PR DESCRIPTION
The following feature flags are re-exported:

  * `sso-min-32bit = ["mqtt-protocol-core/sso-min-32bit"]`
  * `sso-min-64bit = ["mqtt-protocol-core/sso-min-64bit"]`
  * `sso-lv10 = ["mqtt-protocol-core/sso-lv10"]`
  * `sso-lv20 = ["mqtt-protocol-core/sso-lv20"]`